### PR TITLE
Add image for ruby-2.5

### DIFF
--- a/ubuntu-ruby/2.5/Dockerfile
+++ b/ubuntu-ruby/2.5/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.5-alpine
+MAINTAINER openHPI team <openhpi-info@hpi.de>
+
+RUN read command; exec $command
+
+# Install gems for testing
+RUN gem install rspec rspec-expectations
+
+VOLUME /workspace
+WORKDIR /workspace


### PR DESCRIPTION
We need this for our Ruby course.

I decided to use a prebuilt image with a smaller OS (Alpine Linux) - less stuff for us to maintain and smaller in size. Do you see any downsides to this?

@rteusner @tstaubitz 