### PR TITLE
Add Minitest to Ruby 2.5 image

### DIFF
--- a/ubuntu-ruby/2.5/Dockerfile
+++ b/ubuntu-ruby/2.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER openHPI team <openhpi-info@hpi.de>
 RUN read command; exec $command
 
 # Install gems for testing
-RUN gem install rspec rspec-expectations
+RUN gem install rspec rspec-expectations minitest
 
 VOLUME /workspace
 WORKDIR /workspace


### PR DESCRIPTION
We need this as well for some checks in the Ruby course.

Would be cool if you could merge this and update the image used by the execution environment accordingly.

cc @jgraichen 