### PR TITLE
Execute my_init script during startup (as root) and switch user later

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ The following images are probably not compatible with Poseidon or other runner m
 
 ## New or updated images
 
-Each image derived from `docker_exec_phusion` should switch the user at the end of the `Dockerfile`. This ensures that users do not gain elevated privileges in their container: 
-
-```dockerfile
-USER user
-```
+Each image derived from `docker_exec_phusion` should be compatible with a non-privileged user called `user`. Any user code will be executed as this user with the `/sbin/setuser` script provided by the base image.
 
 ### Build
 

--- a/co_execenv_java/17/Dockerfile
+++ b/co_execenv_java/17/Dockerfile
@@ -17,6 +17,3 @@ RUN wget -P /usr/java/lib https://repo1.maven.org/maven2/org/junit/platform/juni
 ENV JAVA_HOME /usr/lib/jvm/java-17-oracle
 ENV JUNIT /usr/java/lib/junit-platform-console-standalone-1.8.1.jar
 ENV CLASSPATH .:$JUNIT
-
-# Switch user
-USER user

--- a/co_execenv_java/8-antlr/Dockerfile
+++ b/co_execenv_java/8-antlr/Dockerfile
@@ -21,6 +21,3 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV JUNIT /usr/java/lib/junit-4.13.jar
 ENV HAMCREST /usr/java/lib/hamcrest-core-1.3.jar
 ENV CLASSPATH .:$JUNIT:$HAMCREST
-
-# Switch user
-USER user

--- a/co_execenv_node/0.12/Dockerfile
+++ b/co_execenv_node/0.12/Dockerfile
@@ -17,8 +17,3 @@ RUN npm install -g mocha@3.2.0 q@1.4.1
 
 # Adjust Path variables
 ENV NODE_PATH=/usr/local/lib/node_modules
-
-# Switch user
-USER user
-
-

--- a/co_execenv_python/3.4-rpi-web/Dockerfile
+++ b/co_execenv_python/3.4-rpi-web/Dockerfile
@@ -21,6 +21,3 @@ RUN pip3 install beautifulsoup4 flask flask-bootstrap
 # Adjust Path variables
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/python3.4:/workspace
 ENV PATH $PATH:/usr/lib/python3.4
-
-# Switch user
-USER user

--- a/co_execenv_python/3.4/Dockerfile
+++ b/co_execenv_python/3.4/Dockerfile
@@ -23,6 +23,3 @@ ADD webpython.py /usr/lib/python3.4/webpython.py
 # Replace maintainers turtle version
 RUN rm /usr/lib/python3.4/turtle.py
 ADD turtle.py /usr/lib/python3.4/turtle.py
-
-# Switch user
-USER user

--- a/co_execenv_python/3.7-ml/Dockerfile
+++ b/co_execenv_python/3.7-ml/Dockerfile
@@ -20,6 +20,3 @@ ENV PATH $PATH:/usr/lib/python3.7
 
 # Add custom files to Python path
 ADD webpython.py /usr/lib/python3.7/webpython.py
-
-# Switch user
-USER user

--- a/co_execenv_python/3.8/Dockerfile
+++ b/co_execenv_python/3.8/Dockerfile
@@ -27,6 +27,3 @@ ADD webpython.py /usr/lib/python3.8/webpython.py
 # Replace maintainers turtle version
 RUN rm /usr/lib/python3.8/turtle.py
 ADD turtle.py /usr/lib/python3.8/turtle.py
-
-# Switch user
-USER user

--- a/co_execenv_r/4/Dockerfile
+++ b/co_execenv_r/4/Dockerfile
@@ -19,6 +19,3 @@ RUN Rscript -e 'remotes::install_github("openHPI/codeoceanR")'
 
 # Adjust Path variables
 ENV PAGER /usr/bin/cat
-
-# Switch user
-USER user

--- a/co_execenv_ruby/2.5/Dockerfile
+++ b/co_execenv_ruby/2.5/Dockerfile
@@ -10,6 +10,3 @@ RUN install_clean ruby2.5 ruby2.5-dev build-essential
 
 # Add some Ruby gems
 RUN gem install rspec rspec-expectations minitest:5.15 rubocop-ast:1.17 rubocop:1.28
-
-# Switch user
-USER user

--- a/docker_exec_phusion/Dockerfile
+++ b/docker_exec_phusion/Dockerfile
@@ -6,7 +6,7 @@ LABEL description='This image is the base for all other execution environments.'
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Create a non-privilidged user called with a new group having the same name
+# Create a non-privileged user called with a new group having the same name
 RUN adduser --disabled-password --home /workspace --no-create-home --gecos "CodeOcean User" user
 
 # The /workspace folder is a location accessible to the user.
@@ -34,6 +34,9 @@ ENV TERM=ansi
 ENV COLUMNS=10000
 # Identify this environment as being part of CodeOcean.
 ENV CODEOCEAN=true
+
+# We start the container with the pre-configured init script and swith to our non-privileged user
+ENTRYPOINT ["/sbin/my_init", "--quiet", "--skip-runit", "--", "/sbin/setuser", "user"]
 
 # We want to start with an empty bash session for any user that launches the container
 CMD ["/bin/bash"]


### PR DESCRIPTION
_Part of https://github.com/openHPI/poseidon/issues/211, //cc @mpass99 and @koelibri_

This PR updates all Docker Images used by CodeOcean to use the `/sbin/my_init` script as [provided by the base image](https://github.com/phusion/baseimage-docker#overview). This init script will serve as a parent process for any new process started and also allows [adding additional daemons](https://github.com/phusion/baseimage-docker#adding-additional-daemons) during Image build.

Also, we change how the user is switched in this PR: Formerly, the user was defined in the last line of each Dockerfile, preventing any execution of `root` by default. Now, we allow `root` to initiate the container and just switch to our non-privileged user for consecutive executions. This change requires the newest version of Poseidon, scoping each new execution with `/sbin/setuser user` (see https://github.com/openHPI/poseidon/issues/215).