### PR TITLE
Update base image to Ubuntu 24.04

### DIFF
--- a/docker_exec_phusion/Dockerfile
+++ b/docker_exec_phusion/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.4
+FROM phusion/baseimage:noble-1.0.0
 MAINTAINER openHPI Team <openhpi-info@hpi.de>
 LABEL description='This image is the base for all other execution environments.'
 


### PR DESCRIPTION
This PR will set the base image to Ubuntu 24.04.

- [x] Check for the [new Ubuntu 24.04 release](https://github.com/phusion/baseimage-docker/releases)
- [x] Wait for #32 