### PR TITLE
Update container build scripts to work with Ubuntu 22.04 and 24.04

### DIFF
--- a/co_execenv_java/17/Dockerfile
+++ b/co_execenv_java/17/Dockerfile
@@ -4,16 +4,18 @@ LABEL description='This image provides a Java 17.0 environment with JUnit 5 supp
 LABEL run_command='make run'
 LABEL test_command='make test CLASS_NAME="%{class_name}" FILENAME="%{filename}"'
 
-# Install latest Java version 17.0
-RUN add-apt-repository ppa:linuxuprising/java --no-update -y
-RUN echo oracle-java17-installer shared/accepted-oracle-license-v1-3 select true | /usr/bin/debconf-set-selections
-RUN install_clean oracle-java17-set-default make
+# Get target architecture from Docker buildx
+ARG TARGETARCH
+
+# Install latest OpenJDK version 17.0
+RUN install_clean openjdk-17-jdk make
 
 # Add JUnit 5 Platform
+ARG JUNIT_VERSION=1.10.2
 RUN mkdir -p /usr/java/lib
-RUN wget -P /usr/java/lib https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.8.1/junit-platform-console-standalone-1.8.1.jar
+RUN curl -fsSL -O --output-dir /usr/java/lib https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/$JUNIT_VERSION/junit-platform-console-standalone-$JUNIT_VERSION.jar
 
 # Adjust Path variables
-ENV JAVA_HOME /usr/lib/jvm/java-17-oracle
-ENV JUNIT /usr/java/lib/junit-platform-console-standalone-1.8.1.jar
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV JUNIT /usr/java/lib/junit-platform-console-standalone-$JUNIT_VERSION.jar
 ENV CLASSPATH .:$JUNIT

--- a/co_execenv_java/8-antlr/Dockerfile
+++ b/co_execenv_java/8-antlr/Dockerfile
@@ -8,8 +8,6 @@ LABEL test_command='make test CLASS_NAME="%{class_name}" FILENAME="%{filename}"'
 ARG TARGETARCH
 
 # Install latest OpenJDK version 8.0
-RUN add-apt-repository ppa:linuxuprising/java --no-update -y
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-2 select true | /usr/bin/debconf-set-selections
 RUN install_clean openjdk-8-jdk make
 
 # Add JUnit 4 and Antlr

--- a/co_execenv_julia/1.10/Dockerfile
+++ b/co_execenv_julia/1.10/Dockerfile
@@ -14,11 +14,11 @@ RUN install_clean clang
 ENV JULIA_HOME /opt/julia
 RUN mkdir -p $JULIA_HOME
 
-# Install Julia version 1.9 with the official binaries
+# Install Julia version 1.10 with the official binaries
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        curl -fsSL https://julialang-s3.julialang.org/bin/linux/aarch64/1.10/julia-1.10.0-beta2-linux-aarch64.tar.gz | tar -xz -C $JULIA_HOME --strip-components=1; \
+        curl -fsSL https://julialang-s3.julialang.org/bin/linux/aarch64/1.10/julia-1.10.2-linux-aarch64.tar.gz | tar -xz -C $JULIA_HOME --strip-components=1; \
     else \
-        curl -fsSL https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.0-beta2-linux-x86_64.tar.gz | tar -xz -C $JULIA_HOME --strip-components=1; \
+        curl -fsSL https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.2-linux-x86_64.tar.gz | tar -xz -C $JULIA_HOME --strip-components=1; \
     fi
 
 # Add Julia to the path

--- a/co_execenv_node/0.12/build_node.sh
+++ b/co_execenv_node/0.12/build_node.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 # Install tools for mk-build-deps
+if [ "$TARGETARCH" = "arm64" ]; then \
+    add-apt-repository -y "deb http://ports.ubuntu.com/ubuntu-ports jammy universe" --no-update; \
+else \
+    add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu jammy universe" --no-update; \
+fi
 install_clean dpkg-dev devscripts equivs python2
 update-alternatives --install /usr/bin/python python /usr/bin/python2 1
 update-alternatives --set python2 /usr/bin/python2

--- a/co_execenv_python/3.7-ml/Dockerfile
+++ b/co_execenv_python/3.7-ml/Dockerfile
@@ -6,11 +6,12 @@ LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 
 # Install Python version 3.7
 RUN add-apt-repository -y ppa:deadsnakes/ppa --no-update
-RUN install_clean python3.7 python3-setuptools python3-pip python3.7-distutils
+RUN install_clean python3.7 python3.7-distutils python3-pip
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
 RUN update-alternatives --set python3 /usr/bin/python3.7
 
 # Add some Python packages
+RUN pip3 install setuptools\<68 # Pylint <2.6 (or, specifically wrapt <1.13) is not compatible with setuptools >=68
 RUN pip3 install wheel pylint\<2.6 bitstring
 RUN pip3 install pandas torch==1.8.1 torchvision==0.9.1 -f https://download.pytorch.org/whl/cpu
 

--- a/co_execenv_python/3.8/Dockerfile
+++ b/co_execenv_python/3.8/Dockerfile
@@ -6,14 +6,15 @@ LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 
 # Install Python version 3.8
 RUN add-apt-repository -y ppa:deadsnakes/ppa --no-update
-RUN install_clean python3.8 python3.8-distutils python3-setuptools python3-pip
+RUN install_clean python3.8 python3.8-distutils python3-pip
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 RUN update-alternatives --set python3 /usr/bin/python3.8
 
 # Add some Python packages
-# `pylint` is used for the linter output
+# `pylint` is used for the linter output and pinned to an older version to get whitespace issues
 # `bitstring` is used for WWW exercises
 # `requests py-sudoku matplotlib numpy beautifulsoup4 tk pandas` is used for the python1 openSAP course
+RUN pip3 install setuptools\<68 # Pylint <2.6 (or, specifically wrapt <1.13) is not compatible with setuptools >=68
 RUN pip3 install wheel pylint\<2.6 bitstring requests py-sudoku matplotlib numpy beautifulsoup4 tk pandas
 
 # Adjust Path variables

--- a/co_execenv_ruby/2.5/Dockerfile
+++ b/co_execenv_ruby/2.5/Dockerfile
@@ -7,14 +7,12 @@ LABEL test_command='rspec --format documentation --no-color %{filename}'
 # Get target architecture from Docker buildx
 ARG TARGETARCH
 
-# Install Ruby version 2.5 with a fixed Ubunut version
-RUN add-apt-repository -y 'deb https://ppa.launchpadcontent.net/ticketsolve/ruby-builds/ubuntu focal main' --no-update
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        add-apt-repository -y "deb http://ports.ubuntu.com/ubuntu-ports focal-updates main" --no-update; \
-    else \
-        add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu focal-updates main" --no-update; \
-    fi
-RUN install_clean build-essential ruby2.5
+# Install Ruby version 2.5 with a fixed Debian version
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 112695A0E562B32A 54404762BBB6E853 648ACFD622F3D138 0E98404D386FA1D9 && \
+    add-apt-repository -y "deb http://deb.debian.org/debian buster main contrib non-free" --no-update; \
+    add-apt-repository -y "deb http://security.debian.org/debian-security/ buster/updates main contrib non-free" --no-update;
+RUN install_clean libncurses6 build-essential libgmp-dev
+RUN install_clean -t buster ruby2.5 ruby2.5-dev
 
 # Add some Ruby gems
 RUN gem install rspec rspec-expectations minitest:5.15 rubocop-ast:1.17 rubocop:1.28


### PR DESCRIPTION
This PR fixes all current build issues and is already compatible with Ubuntu 24.04.

Missing images:
- [x] Python 3.7: [Deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)
- [x] Python 3.8: [Deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)
- [x] R 4.x (amd64): [CRAN binaries](https://cloud.r-project.org/bin/linux/ubuntu/)
