### PR TITLE
Fix NodeJS build issues for amd64

### DIFF
--- a/co_execenv_node/0.12/build_node.sh
+++ b/co_execenv_node/0.12/build_node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Install tools for mk-build-deps
+# Install tools for mk-build-deps using the jammy repository. Otherwise, Python2 is not available
 if [ "$TARGETARCH" = "arm64" ]; then \
     add-apt-repository -y "deb http://ports.ubuntu.com/ubuntu-ports jammy universe" --no-update; \
 else \
@@ -33,12 +33,29 @@ apt-get source nodejs=0.12.18-1nodesource1~xenial1
 cd nodejs-0.12.18 && mk-build-deps --install --remove --tool 'apt-get --no-install-recommends --yes'
 
 sed -i 's/-dumpversion/-dumpfullversion/g' /tmp/build/nodejs-0.12.18/configure
-./configure --dest-cpu=arm64
+./configure --dest-cpu=arm64 # Always build for arm64, even on amd64
 if [ "$TARGETARCH" = "arm64" ]; then \
     sed -i 's/__x86_64__/__aarch64__/g' /tmp/build/nodejs-0.12.18/deps/openssl/config/opensslconf.h && \
     sed -i 's/-m64//g' /tmp/build/nodejs-0.12.18/deps/v8/build/toolchain.gypi; \
+fi
+
+# Run `make install` with retries.
+# On some systems, the build process may fail due to a lack of memory.
+# Luckily, the build process is resumable, so we can retry it.
+make_retry_count=0
+make_max_retries=3
+until make install
+do
+    make_retry_count=$((make_retry_count + 1))
+    echo
+    if [ $make_retry_count -ge $make_max_retries ]; then
+        echo "Failed to make install after $make_retry_count attempts."
+        exit 1
+    else
+        echo "Failed to make install, retrying..."
+        sleep 1
     fi
-make install
+done
 ln -fs /usr/local/bin/node /usr/local/bin/nodejs
 
 # Clean source files


### PR DESCRIPTION
Previously, NodeJS would only build for arm64-based systems, but not for amd64-based systems. The solution chosen is a bit hacky, but the overall approach to compile Node is anyways 🤷.