### PR TITLE
Hide environment variables

### DIFF
--- a/docker_exec_phusion/Dockerfile
+++ b/docker_exec_phusion/Dockerfile
@@ -37,8 +37,8 @@ ENV COLUMNS=10000
 # Identify this environment as being part of CodeOcean.
 ENV CODEOCEAN=true
 
-# We start the container with the pre-configured init script and swith to our non-privileged user
-ENTRYPOINT ["/sbin/my_init", "--quiet", "--skip-runit", "--", "/sbin/setuser", "user"]
+# We start the container with the pre-configured init script and switch to our non-privileged user without access to the environment variables
+ENTRYPOINT ["/sbin/my_init", "--quiet", "--skip-runit", "--", "env", "-i", "/sbin/setuser", "user"]
 
 # We want to start with an empty bash session for any user that launches the container
 CMD ["/bin/bash"]


### PR DESCRIPTION
from unprivileged user.

For Poseidon, the entry point is just used for the `sleep infinity` command. However, because it is run as the unprivileged `user` the environment can be accessed. This undermines [our efforts in Poseidon](https://github.com/openHPI/poseidon/blob/8390b90fe21e393f96421ae5ca8d7f415e7b680c/internal/nomad/nomad.go#L733) to hide the environment variables.