### PR TITLE
Resolve deprecation warnings for Docker

### DIFF
--- a/co_execenv_java/17/Dockerfile
+++ b/co_execenv_java/17/Dockerfile
@@ -16,6 +16,6 @@ RUN mkdir -p /usr/java/lib
 RUN curl -fsSL -O --output-dir /usr/java/lib https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/$JUNIT_VERSION/junit-platform-console-standalone-$JUNIT_VERSION.jar
 
 # Adjust Path variables
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-$TARGETARCH
-ENV JUNIT /usr/java/lib/junit-platform-console-standalone-$JUNIT_VERSION.jar
-ENV CLASSPATH .:$JUNIT
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-$TARGETARCH
+ENV JUNIT=/usr/java/lib/junit-platform-console-standalone-$JUNIT_VERSION.jar
+ENV CLASSPATH=.:$JUNIT

--- a/co_execenv_java/17/Dockerfile
+++ b/co_execenv_java/17/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Java 17.0 environment with JUnit 5 support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Java 17 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Java 17.0 environment with JUnit 5 support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='make run'
 LABEL test_command='make test CLASS_NAME="%{class_name}" FILENAME="%{filename}"'
 

--- a/co_execenv_java/8-antlr/Dockerfile
+++ b/co_execenv_java/8-antlr/Dockerfile
@@ -25,9 +25,9 @@ RUN curl -fsSL -O --output-dir /usr/java/lib https://www.antlr.org/download/antl
 ADD antlr-java8.jar /usr/java/lib/
 
 # Adjust Path variables
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-$TARGETARCH
-ENV HAMCREST /usr/java/lib/hamcrest-$HAMCREST_VERSION.jar
-ENV JUNIT /usr/java/lib/junit-$JUNIT_VERSION.jar
-ENV ANTLR /usr/java/lib/antlr-${ANTLR_VERSION}-complete.jar
-ENV ANTLR_JAVA8 /usr/java/lib/antlr-java8.jar
-ENV CLASSPATH .:$HAMCREST:$JUNIT:$ANTLR:$ANTLR_JAVA8
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-$TARGETARCH
+ENV HAMCREST=/usr/java/lib/hamcrest-$HAMCREST_VERSION.jar
+ENV JUNIT=/usr/java/lib/junit-$JUNIT_VERSION.jar
+ENV ANTLR=/usr/java/lib/antlr-${ANTLR_VERSION}-complete.jar
+ENV ANTLR_JAVA8=/usr/java/lib/antlr-java8.jar
+ENV CLASSPATH=.:$HAMCREST:$JUNIT:$ANTLR:$ANTLR_JAVA8

--- a/co_execenv_java/8-antlr/Dockerfile
+++ b/co_execenv_java/8-antlr/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides an OpenJDK 8.0 environment with JUnit 4 and Antlr support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Java 8 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides an OpenJDK 8.0 environment with JUnit 4 and Antlr support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='make run CLASS_NAME="%{class_name}" FILENAME="%{filename}"'
 LABEL test_command='make test CLASS_NAME="%{class_name}" FILENAME="%{filename}"'
 

--- a/co_execenv_julia/1.10/Dockerfile
+++ b/co_execenv_julia/1.10/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 RUN install_clean clang
 
 # Create a directory for Julia
-ENV JULIA_HOME /opt/julia
+ENV JULIA_HOME=/opt/julia
 RUN mkdir -p $JULIA_HOME
 
 # Install Julia version 1.10 with the official binaries
@@ -23,7 +23,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 # Add Julia to the path
-ENV PATH $PATH:$JULIA_HOME/bin
+ENV PATH=$PATH:$JULIA_HOME/bin
 
 # Install Julia packages and rebuild the system image
 RUN JULIA_DEPOT_PATH=$JULIA_HOME/share/julia julia -e 'import Pkg; Pkg.add("PackageCompiler")'

--- a/co_execenv_julia/1.10/Dockerfile
+++ b/co_execenv_julia/1.10/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Julia 1.10 environment.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Julia 1.10 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Julia 1.10 environment.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='julia --color=no %{filename}'
 LABEL test_command='julia --color=no %{filename}'
 

--- a/co_execenv_julia/1.8/Dockerfile
+++ b/co_execenv_julia/1.8/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Julia 1.8 environment.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Julia 1.8 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Julia 1.8 environment.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='julia --color=no %{filename}'
 LABEL test_command='julia --color=no %{filename}'
 

--- a/co_execenv_julia/1.8/Dockerfile
+++ b/co_execenv_julia/1.8/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 RUN install_clean clang
 
 # Create a directory for Julia
-ENV JULIA_HOME /opt/julia
+ENV JULIA_HOME=/opt/julia
 RUN mkdir -p $JULIA_HOME
 
 # Install Julia version 1.8 with the official binaries
@@ -23,7 +23,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 # Add Julia to the path
-ENV PATH $PATH:$JULIA_HOME/bin
+ENV PATH=$PATH:$JULIA_HOME/bin
 
 # Install Julia packages and rebuild the system image
 ARG JULIA_DEPOT_PATH=$JULIA_HOME/share/julia

--- a/co_execenv_node/0.12/Dockerfile
+++ b/co_execenv_node/0.12/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Node 0.12 environment with npm, mocha and q.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Node 0.12 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Node 0.12 environment with npm, mocha and q.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='node %{filename}'
 LABEL test_command='mocha | iconv -c -t ASCII'
 

--- a/co_execenv_python/3.4-rpi-web/Dockerfile
+++ b/co_execenv_python/3.4-rpi-web/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Python 3.4 environment with selenium and flask support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Python 3.4 execution environment with selenium and flask for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Python 3.4 environment with selenium and flask support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='make run'
 LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 

--- a/co_execenv_python/3.4-rpi-web/Dockerfile
+++ b/co_execenv_python/3.4-rpi-web/Dockerfile
@@ -20,13 +20,13 @@ RUN curl -fsSL https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz | 
 RUN cd $OPENSSL_TMP_DIR && ./config -fPIC -shared && make install
 
 # Set environment variables for OpenSSL
-ENV OPENSSL_INCLUDE_DIR /usr/local/ssl/include
-ENV OPENSSL_LIB_DIR /usr/local/ssl/lib
-ENV LD_LIBRARY_PATH $OPENSSL_LIB_DIR
+ENV OPENSSL_INCLUDE_DIR=/usr/local/ssl/include
+ENV OPENSSL_LIB_DIR=/usr/local/ssl/lib
+ENV LD_LIBRARY_PATH=$OPENSSL_LIB_DIR
 
 # Install Python version 3.4
 ARG PYTHON_TMP_DIR=/tmp/python3
-ENV PYTHON_DIR /usr/lib/python3.4
+ENV PYTHON_DIR=/usr/lib/python3.4
 RUN mkdir -p $PYTHON_TMP_DIR
 RUN curl -fsSL https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tgz | tar -xz -C $PYTHON_TMP_DIR --strip-components=1
 RUN cd $PYTHON_TMP_DIR && CPPFLAGS="-I/usr/include/tirpc -I$OPENSSL_INCLUDE_DIR" LDFLAGS="-L$OPENSSL_LIB_DIR" ./configure --prefix=/usr && LD_LIBRARY_PATH="/usr/local/ssl/lib" make altinstall
@@ -50,5 +50,5 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.4 1
 RUN update-alternatives --set python3 /usr/bin/python3.4
 
 # Adjust Path variables
-ENV PYTHONPATH $PYTHONPATH:$PYTHON_DIR:/workspace
-ENV PATH $PATH:$PYTHON_DIR
+ENV PYTHONPATH=$PYTHONPATH:$PYTHON_DIR:/workspace
+ENV PATH=$PATH:$PYTHON_DIR

--- a/co_execenv_python/3.4/Dockerfile
+++ b/co_execenv_python/3.4/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Python 3.4 environment with custom JSON message output and turtle support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Python 3.4 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Python 3.4 environment with custom JSON message output and turtle support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='python3 -B /usr/lib/python3.4/webpython.py -f %{filename}'
 LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 

--- a/co_execenv_python/3.4/Dockerfile
+++ b/co_execenv_python/3.4/Dockerfile
@@ -20,13 +20,13 @@ RUN curl -fsSL https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz | 
 RUN cd $OPENSSL_TMP_DIR && ./config -fPIC -shared && make install
 
 # Set environment variables for OpenSSL
-ENV OPENSSL_INCLUDE_DIR /usr/local/ssl/include
-ENV OPENSSL_LIB_DIR /usr/local/ssl/lib
-ENV LD_LIBRARY_PATH $OPENSSL_LIB_DIR
+ENV OPENSSL_INCLUDE_DIR=/usr/local/ssl/include
+ENV OPENSSL_LIB_DIR=/usr/local/ssl/lib
+ENV LD_LIBRARY_PATH=$OPENSSL_LIB_DIR
 
 # Install Python version 3.4
 ARG PYTHON_TMP_DIR=/tmp/python3
-ENV PYTHON_DIR /usr/lib/python3.4
+ENV PYTHON_DIR=/usr/lib/python3.4
 RUN mkdir -p $PYTHON_TMP_DIR
 RUN curl -fsSL https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tgz | tar -xz -C $PYTHON_TMP_DIR --strip-components=1
 RUN cd $PYTHON_TMP_DIR && CPPFLAGS="-I/usr/include/tirpc -I$OPENSSL_INCLUDE_DIR" LDFLAGS="-L$OPENSSL_LIB_DIR" ./configure --prefix=/usr && LD_LIBRARY_PATH="/usr/local/ssl/lib" make altinstall
@@ -43,8 +43,8 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.4 1
 RUN update-alternatives --set python3 /usr/bin/python3.4
 
 # Adjust Path variables
-ENV PYTHONPATH $PYTHONPATH:$PYTHON_DIR:/workspace
-ENV PATH $PATH:$PYTHON_DIR
+ENV PYTHONPATH=$PYTHONPATH:$PYTHON_DIR:/workspace
+ENV PATH=$PATH:$PYTHON_DIR
 
 # Add custom files to Python path
 ADD assess.py $PYTHON_DIR/assess.py

--- a/co_execenv_python/3.7-ml/Dockerfile
+++ b/co_execenv_python/3.7-ml/Dockerfile
@@ -16,8 +16,8 @@ RUN pip3 install wheel pylint\<2.6 bitstring
 RUN pip3 install pandas torch==1.8.1 torchvision==0.9.1 -f https://download.pytorch.org/whl/cpu
 
 # Adjust Path variables
-ENV PYTHONPATH $PYTHONPATH:/usr/lib/python3.7:/workspace
-ENV PATH $PATH:/usr/lib/python3.7
+ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.7:/workspace
+ENV PATH=$PATH:/usr/lib/python3.7
 
 # Add custom files to Python path
 ADD webpython.py /usr/lib/python3.7/webpython.py

--- a/co_execenv_python/3.7-ml/Dockerfile
+++ b/co_execenv_python/3.7-ml/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Python 3.7 environment with custom JSON message output and Machine Learning support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Python 3.7 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Python 3.7 environment with custom JSON message output and Machine Learning support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='python3 -B /usr/lib/python3.7/webpython.py -f %{filename}'
 LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 

--- a/co_execenv_python/3.8/Dockerfile
+++ b/co_execenv_python/3.8/Dockerfile
@@ -18,8 +18,8 @@ RUN pip3 install setuptools\<68 # Pylint <2.6 (or, specifically wrapt <1.13) is 
 RUN pip3 install wheel pylint\<2.6 bitstring requests py-sudoku matplotlib numpy beautifulsoup4 tk pandas
 
 # Adjust Path variables
-ENV PYTHONPATH $PYTHONPATH:/usr/lib/python3.8:/workspace
-ENV PATH $PATH:/usr/lib/python3.8
+ENV PYTHONPATH=$PYTHONPATH:/usr/lib/python3.8:/workspace
+ENV PATH=$PATH:/usr/lib/python3.8
 
 # Add custom files to Python path
 ADD assess.py /usr/lib/python3.8/assess.py

--- a/co_execenv_python/3.8/Dockerfile
+++ b/co_execenv_python/3.8/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Python 3.8 environment with custom JSON message output and turtle support.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Python 3.8 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Python 3.8 environment with custom JSON message output and turtle support.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='python3 -B /usr/lib/python3.8/webpython.py -f %{filename}'
 LABEL test_command='python3 -B -m unittest --verbose %{module_name}'
 

--- a/co_execenv_r/4/Dockerfile
+++ b/co_execenv_r/4/Dockerfile
@@ -26,4 +26,4 @@ RUN Rscript -e 'remotes::install_github("brry/berryFunctions")'
 RUN Rscript -e 'remotes::install_github("openHPI/codeoceanR")'
 
 # Adjust Path variables
-ENV PAGER /usr/bin/cat
+ENV PAGER=/usr/bin/cat

--- a/co_execenv_r/4/Dockerfile
+++ b/co_execenv_r/4/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a R 4.0 environment with custom libraries from Berry.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='R 4.0 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a R 4.0 environment with custom libraries from Berry.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='Rscript -e "options(warn=1); source('%{filename}', echo=TRUE)"'
 LABEL test_command='Rscript %{filename}'
 

--- a/co_execenv_ruby/2.5/Dockerfile
+++ b/co_execenv_ruby/2.5/Dockerfile
@@ -1,6 +1,9 @@
 FROM openhpi/docker_exec_phusion
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image provides a Ruby 2.5 environment with rspec, minitest and rubocop.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Ruby 2.5 execution environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image provides a Ruby 2.5 environment with rspec, minitest and rubocop.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 LABEL run_command='ruby %{filename}'
 LABEL test_command='rspec --format documentation --no-color %{filename}'
 

--- a/docker_exec_phusion/Dockerfile
+++ b/docker_exec_phusion/Dockerfile
@@ -27,9 +27,9 @@ WORKDIR /workspace
 # Generate English locale files
 RUN locale-gen en_US.UTF-8
 # Set English as the main language and UTF-8 as desired encoding
-ENV LANGUAGE en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 # Specify terminal emulation.
 ENV TERM=ansi
 # Prevent folding of output (for lines not longer than 10000 characters).

--- a/docker_exec_phusion/Dockerfile
+++ b/docker_exec_phusion/Dockerfile
@@ -1,6 +1,9 @@
 FROM phusion/baseimage:noble-1.0.0
-MAINTAINER openHPI Team <openhpi-info@hpi.de>
-LABEL description='This image is the base for all other execution environments.'
+LABEL org.opencontainers.image.vendor='openHPI Team'
+LABEL org.opencontainers.image.authors='openhpi-info@hpi.de'
+LABEL org.opencontainers.image.title='Base exeuction environment for CodeOcean'
+LABEL org.opencontainers.image.description='This image is the base for all other execution environments.'
+LABEL org.opencontainers.image.url='https://github.com/openHPI/dockerfiles'
 
 # Update the system
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \


### PR DESCRIPTION
Creating the Docker containers previously resulted in the following two deprecation warnings being issued:

```
 2 warnings found (use docker --debug to expand):
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 28)
```

This PR fixes these deprecation warnings and adds 