### PR TITLE
fix: Use r-porject packages for ARM

### DIFF
--- a/co_execenv_r/4/Dockerfile
+++ b/co_execenv_r/4/Dockerfile
@@ -11,13 +11,9 @@ LABEL test_command='Rscript %{filename}'
 ARG TARGETARCH
 
 # Install latest R version 4.0
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        # Update distribution regularly to match newest version: https://launchpad.net/ubuntu/+source/r-base
-        add-apt-repository -y "deb http://ports.ubuntu.com/ubuntu-ports oracular universe" --no-update; \
-    else \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
-        add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"  --no-update; \
-    fi
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+      add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"  --no-update
+
 RUN install_clean r-base build-essential libcurl4-openssl-dev libssl-dev libpoppler-cpp-dev poppler-data libjpeg-dev libz-dev
 
 # Add custom packages


### PR DESCRIPTION
Avoid access issues to ports.ubuntu.com. r-project provides ARM packages. No ARM specific settings are necessary.